### PR TITLE
realmeParts: Cleanup unnecessary static libs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -27,8 +27,7 @@ LOCAL_PACKAGE_NAME := RealmeParts
 LOCAL_USE_AAPT2 := true
 
 LOCAL_STATIC_ANDROID_LIBRARIES := \
-    androidx.core_core \
-    androidx.preference_preference
+    SettingsLib
 
 LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/res \
@@ -44,5 +43,4 @@ LOCAL_RESOURCE_DIR := $(package_resource_overlays) $(LOCAL_RESOURCE_DIR)
 LOCAL_PROGUARD_ENABLED := optimization
 LOCAL_PROGUARD_FLAG_FILES := proguard.flags
 LOCAL_MODULE_TAGS := optional
-include frameworks/base/packages/SettingsLib/common.mk
 include $(BUILD_PACKAGE)


### PR DESCRIPTION
Fixes an error in 13 regarding duplicate manifest properties.

Change-Id: I4f029bfa50b9948a894c96edab252a5340477d99
Signed-off-by: Aryan Sinha <sinha.aryan03@gmail.com>